### PR TITLE
Update doctr deploy API usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ script:
   - make pools && make images && make html
   - cd ..
   - git config --global user.email "placeholder@placeholder.com"
-  - doctr deploy
+  - doctr deploy docs


### PR DESCRIPTION
doctr now requires the deploy directory as an argument and the `--gh-pages-docs` flag is deprecated.