### PR TITLE
Update doctr deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ script:
   - make pools && make images && make html
   - cd ..
   - git config --global user.email "placeholder@placeholder.com"
-  - doctr deploy
+  - doctr deploy docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ script:
   - make pools && make images && make html
   - cd ..
   - git config --global user.email "placeholder@placeholder.com"
-  - doctr deploy docs
+  - doctr deploy docs --built-docs doc/build/html


### PR DESCRIPTION
The `--gh-pages-docs` flag is deprecated and the deploy directory is now a required argument.