### PR TITLE
Fix bit rot.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+# show coverage in CI status, not as a comment.
+comment: off
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+source =
+    photomosaic
+[report]
+omit =
+    */python?.?/*
+    */site-packages/nose/*
+    # ignore _version.py and versioneer.py
+    .*version.*
+    *_version.py
+
+exclude_lines =
+    if __name__ == '__main__':

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+exclude = .git,__pycache__,build,dist,versioneer.py,photomosaic/_version.py,doc/source/conf.py
+max_line_length = 115

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ photomosaic.egg-info/
 build/
 dist/
 doc/source/_static/generated_images/*.png
-.coverage*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
+dist: xenial
 language: python
 sudo: false
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      env: PUBLISH_DOCS=1
 
 cache:
   directories:
@@ -7,42 +15,29 @@ cache:
     - $HOME/.cache/matplotlib
     - $HOME/pools/
 
-matrix:
-  include:
-    - python: 3.5
-
 env:
   global:
+    # Doctr deploy key for danielballan.github.io/photomosaic
     - secure: "f6PzI9At5FKvozluhLQnOvNB2wwVdvoVA7hur4PN5E5PbHWeICeNbj15VkIxChUUUwTXEI/mSMMRvYpDHFr205RxaNuv+/lyLo4H1VqiVlZvZi6jJLB2paYwu0AqsAeTjO5XrgKgByuwWDlQIwP02hnxgGD3LbD83h/Trh0Yln4="
 
-before_install:
-  - "export DISPLAY=:99.0"
-  - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b -p /home/travis/mc
-  - export PATH=/home/travis/mc/bin:$PATH
-  - conda config --set show_channel_urls True
-  - conda config --set always_yes True
-
 install:
-  - export GIT_FULL_HASH=`git rev-parse HEAD`
-  # Install heavy stuff with conda, for speed.
-  - conda create -n testenv python=$TRAVIS_PYTHON_VERSION scipy numpy coverage scikit-image pip -c conda-forge
-  - source activate testenv
-  - git fetch origin --tags  # used by versioneer
+  # Install this package and the packages listed in requirements.txt.
   - pip install .[parallel]
-  - pip install pytest codecov pytest-cov
-  # Need to clean the python build directory (and other cruft) or pytest is
-  # going to find the build directory and get confused why there are two sets
-  # of every test file
-  - git clean -xfd
+  # Install extra requirements for running tests and building docs.
+  - pip install -r requirements-dev.txt
 
 script:
-  - python run_tests.py
-  - coverage report -m
-  - pip install doctr sphinx numpydoc ipython sphinx_rtd_theme  # docs dependencies
-  - cd doc
-  - make pools && make images && make html
-  - cd ..
-  - git config --global user.email "placeholder@placeholder.com"
-  - doctr deploy docs --built-docs doc/build/html
+  - coverage run -m pytest  # Run the tests and check for test coverage.
+  - coverage report -m  # Generate test coverage report.
+  - codecov  # Upload the report to codecov.
+  - flake8  # Enforce code style.
+  - set -e
+  - make -C doc pools  # Generate tile pools used in documentation.
+  - make -C doc images  # Generate example images used in documentation.
+  - make -C doc html  # Build the documentation.
+  - |
+    if [ $PUBLISH_DOCS ]; then
+      # Pubish the documentation to GitHub Pages.
+      pip install doctr;
+      doctr deploy docs --built-docs doc/build/html;
+    fi

--- a/doc/examples/06-cat-of-cats.py
+++ b/doc/examples/06-cat-of-cats.py
@@ -1,9 +1,0 @@
-import photomosaic as pm
-import matplotlib.pyplot as plt
-
-
-# Build mosaic.
-pool = pm.import_pool('~/pools/cats/pool.json')
-mosaic = pm.basic_mosaic(img, pool, (30, 30), depth=4)
-plt.plot(mosaic)
-plt.show()

--- a/doc/pool_scripts/cats.py
+++ b/doc/pool_scripts/cats.py
@@ -3,10 +3,24 @@ import photomosaic.flickr
 import photomosaic as pm
 
 
+class MissingAPIKey(Exception):
+    ...
+
+
 if not os.path.isfile(os.path.expanduser('~/pools/cats/pool.json')):
-    FLICKR_API_KEY = os.environ['FLICKR_API_KEY']
+    try:
+        FLICKR_API_KEY = os.environ['FLICKR_API_KEY']
+    except KeyError:
+        raise MissingAPIKey(
+            "This script requires the environment variable FLICKR_API_KEY "
+            "to run. It will be not be available on pull requests from "
+            "other forks. See "
+            "https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions"
+            ) from None
     pm.set_options(flickr_api_key=FLICKR_API_KEY)
 
     photomosaic.flickr.from_search('cats', '~/pools/cats/')
     pool = pm.make_pool('~/pools/cats/*.jpg')
     pm.export_pool(pool, '~/pools/cats/pool.json')  # save color analysis for future reuse
+else:
+    print("Pool was found in ~pools/cats/. No action needed.")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -43,6 +43,7 @@ extensions = [
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
     'matplotlib.sphinxext.plot_directive',
+    'sphinx_copybutton',
 ]
 
 # Configuration options for plot_directive. See:

--- a/doc/source/scripts/03-basic.py
+++ b/doc/source/scripts/03-basic.py
@@ -1,5 +1,7 @@
 import os
 import photomosaic as pm
+from skimage import data
+from skimage.io import imsave
 
 
 here = os.path.dirname(__file__)
@@ -7,9 +9,7 @@ POOL_PATH = '/tmp/photomosaic-docs-pool/pool.json'
 pool = pm.import_pool(os.path.join(POOL_PATH))
 
 # Load a sample image
-from skimage import data
 img = data.chelsea()  # cat picture!
 # Create a mosiac with 15x15 tiles.
 mos = pm.basic_mosaic(img, pool, (30, 30))
-from skimage.io import imsave
 imsave(os.path.join(here, '..', '_static', 'generated_images', 'basic.png'), mos)

--- a/doc/source/scripts/04-basic-depth1.py
+++ b/doc/source/scripts/04-basic-depth1.py
@@ -1,5 +1,7 @@
 import os
 import photomosaic as pm
+from skimage import data
+from skimage.io import imsave
 
 
 here = os.path.dirname(__file__)
@@ -7,9 +9,7 @@ POOL_PATH = '/tmp/photomosaic-docs-pool/pool.json'
 pool = pm.import_pool(os.path.join(POOL_PATH))
 
 # Load a sample image
-from skimage import data
 img = data.chelsea()  # cat picture!
 # Create a mosiac with 15x15 tiles.
 mos = pm.basic_mosaic(img, pool, (30, 30), depth=1)
-from skimage.io import imsave
 imsave(os.path.join(here, '..', '_static', 'generated_images', 'basic-depth1.png'), mos)

--- a/doc/source/scripts/05-no-palette-adjustment.py
+++ b/doc/source/scripts/05-no-palette-adjustment.py
@@ -1,4 +1,3 @@
-from tqdm import tqdm
 import os
 import numpy as np
 import photomosaic as pm

--- a/photomosaic/__init__.py
+++ b/photomosaic/__init__.py
@@ -1,4 +1,4 @@
-from .photomosaic import *
+from .photomosaic import *  # noqa
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/photomosaic/flickr.py
+++ b/photomosaic/flickr.py
@@ -129,7 +129,7 @@ def _try_retrieve_warn_failure(url, filepath):
     for _ in range(3):
         try:
             urllib.request.urlretrieve(url, filepath)
-        except urllib.error.HTTPError as error:
+        except urllib.error.URLError as error:
             errors.append(error)
             continue  # try again
         else:

--- a/photomosaic/photomosaic.py
+++ b/photomosaic/photomosaic.py
@@ -856,7 +856,8 @@ def crop_to_fit(image, shape):
     enlarged_shape = (tuple(np.ceil(np.array(image.shape[:len(shape)]) *
                                     shape[d]/image.shape[d])) +
                       image.shape[len(shape):])
-    resized = resize(image, enlarged_shape)
+    resized = resize(image, enlarged_shape,
+                     mode='constant', anti_aliasing=False)
     # Now the image is as large or larger than the shape along all dimensions.
     # Crop any overhang in the other dimension.
     crop_width = []

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = test.py photomosaic/
+python_files = test*.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,13 @@
+# These are required for developing the package (running the tests, building
+# the documentation) but not necessarily required for _using_ it.
+codecov
+coverage
+flake8
+pytest >3.9
+sphinx
+# These are dependencies of various sphinx extensions for documentation.
+ipython
+matplotlib
+numpydoc
+sphinx-copybutton
+sphinx_rtd_theme


### PR DESCRIPTION
The only changes to the package itself are adding some argument to skimage function calls to avoid deprecation warnings. Lots of changes to the CI:

* Test on all versions of Python 3 that are not end-of-life'd (3.5, 3.6, 3.7).
* Use pip instead of conda. (Conda was faster back when pip didn't have binary wheels, but now it does.)
* Simplify and add a bunch of comments to make the `.travis.yml` easier to follow.
* Add config files for pytest, coverage, codecov, flake8.
* Make the flickr downloader more fault tolerant of the occasional broken URL.
* Improve the error message when `FLICKR_API_KEY` is missing.