### PR TITLE
Remove run_tests.py. (Just execute pytest.)

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python
-import sys
-import pytest
-
-if __name__ == '__main__':
-    args = ['-vrxs', '--cov', 'photomosaic', 'test.py']
-    if len(sys.argv) > 1:
-        args.extend(sys.argv[1:])
-    sys.exit(pytest.main(args))


### PR DESCRIPTION
The `pytest.ini` provides the information pytest needs, so there is no
need for a custom file.